### PR TITLE
Add "hacky" skulls with custom skin support

### DIFF
--- a/resources/config.yml
+++ b/resources/config.yml
@@ -30,7 +30,9 @@
 # itemframes          - Enables experimental caching and mucking with packets to support itemframes for PE players.
 # teams               - Enables experimental caching and mucking with packets to support team prefix/suffixes for PE players.
 # bossbars            - Enables experimental caching and mucking with packets to boss bars for PE players.
-# player-heads-skins  - Enables experimental caching, "player heads to players" replacement and skin replacement to support player heads with skins for PE players.
+# player-heads-skins  - Options related to player heads with custom skins
+#   skull-blocks      - Enables experimental caching, "player heads to players" replacement to support player heads with skins for PE players.
+#   equipped-blocks   - Enables experimental caching, skin replacement to support equipped player heads with skins for PE players.
 #
 # !Do not change the config-version unless you know what you are doing!
 
@@ -52,5 +54,7 @@ hacks:
  itemframes: false
  teams: false
  bossbars: false
- player-heads-skins: false
+ player-heads-skins:
+   skull-blocks: false
+   equipped-blocks: false
 config-version: 1

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -52,9 +52,5 @@ hacks:
  itemframes: false
  teams: false
  bossbars: false
-<<<<<<< HEAD
  player-heads-skins: false
 config-version: 1
-=======
-config-version: 1
->>>>>>> origin/master

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -24,11 +24,12 @@
 #
 # Packs must be added to ./plugins/ProtocolSupportPocketStuff/pocketpacks
 # = Hacks =
-# dimensions  - Enables using bukkit to fake dimension switching for pocket players.
-# holograms   - Enables experimental caching and "armor stand to player" replacement to support holograms for PE players.
-# itemframes  - Enables experimental caching and mucking with packets to support itemframes for PE players.
-# teams       - Enables experimental caching and mucking with packets to support team prefix/suffixes for PE players.
-# bossbars    - Enables experimental caching and mucking with packets to boss bars for PE players.
+# dimensions          - Enables using bukkit to fake dimension switching for pocket players.
+# holograms           - Enables experimental caching and "armor stand to player" replacement to support holograms for PE players.
+# itemframes          - Enables experimental caching and mucking with packets to support itemframes for PE players.
+# teams               - Enables experimental caching and mucking with packets to support team prefix/suffixes for PE players.
+# bossbars            - Enables experimental caching and mucking with packets to boss bars for PE players.
+# player-heads-skins  - Enables experimental caching, "player heads to players" replacement and skin replacement to support player heads with skins for PE players.
 # !Do not change the config-version unless you know what you are doing!
 logging:
  disable-colors: false
@@ -48,4 +49,5 @@ hacks:
  itemframes: false
  teams: false
  bossbars: false
+ player-heads-skins: false
 config-version: 1

--- a/resources/resources/models/fake_skull_block.json
+++ b/resources/resources/models/fake_skull_block.json
@@ -1,0 +1,52 @@
+{
+  "geometry.Tiles.PSPEFakeSkull": {
+    "bones": [
+      {
+        "pivot": [ 0, 24, 0 ],
+         "rotation": [ 0, 0, 0 ],
+          "cubes": [ 
+           {
+            "origin": [ -4, 0, -4 ],
+            "size": [ 8, 8, 8 ],
+            "uv": [ 0, 0 ],
+            "inflate": 0,
+            "mirror": false
+          }
+        ],
+        "META_BoneType": "base",
+        "name": "head",
+        "parent": null
+      },
+      {
+        "pivot": [ 0, 24, 0 ],
+         "rotation": [ 0, 0, 0 ],
+          "cubes": [ 
+           {
+            "origin": [ -4, 0, -4 ],
+            "size": [ 8, 8, 8 ],
+            "uv": [ 32, 0 ],
+            "inflate": 0.5,
+            "mirror": false
+          }
+        ],
+        "META_BoneType": "clothing",
+        "name": "hat",
+        "parent": "head"
+      }
+    ],
+    "texturewidth": 64,
+    "textureheight": 64,
+    "META_ModelVersion": "1.0.6",
+    "rigtype": "normal",
+    "animationArmsDown": false,
+    "animationArmsOutFront": false,
+    "animationStatueOfLibertyArms": false,
+    "animationSingleArmAnimation": true,
+    "animationStationaryLegs": true,
+    "animationSingleLegAnimation": false,
+    "animationNoHeadBob": true,
+    "animationDontShowArmor": true,
+    "animationUpsideDown": false,
+    "animationInvertedCrouch": false
+  }
+}

--- a/src/protocolsupportpocketstuff/ProtocolSupportPocketStuff.java
+++ b/src/protocolsupportpocketstuff/ProtocolSupportPocketStuff.java
@@ -88,7 +88,7 @@ public class ProtocolSupportPocketStuff extends JavaPlugin implements Listener {
 			con.addPacketListener(new ResourcePackListener(this, con));
 			if (getConfig().getBoolean("skins.PEtoPC")) { con.addPacketListener(new SkinPacket().new decodeHandler(this, con)); }
 			if (getConfig().getBoolean("hacks.holograms")) { con.addPacketListener(new HologramsPacketListener(this, con)); }
-			if (getConfig().getBoolean("hacks.player-heads-skins")) { con.addPacketListener(new PlayerHeadsPacketListener(this, con)); }
+			if (getConfig().getBoolean("hacks.player-heads-skins.skull-blocks")) { con.addPacketListener(new PlayerHeadsPacketListener(this, con)); }
 			if (platform == ServerPlatformIdentifier.SPIGOT) { // Spigot only hacks
 				if (getConfig().getBoolean("hacks.teams")) {
 					con.addPacketListener(new TeamsPacketListener(this, con));

--- a/src/protocolsupportpocketstuff/ProtocolSupportPocketStuff.java
+++ b/src/protocolsupportpocketstuff/ProtocolSupportPocketStuff.java
@@ -88,7 +88,7 @@ public class ProtocolSupportPocketStuff extends JavaPlugin implements Listener {
 			con.addPacketListener(new ResourcePackListener(this, con));
 			if (getConfig().getBoolean("skins.PEtoPC")) { con.addPacketListener(new SkinPacket().new decodeHandler(this, con)); }
 			if (getConfig().getBoolean("hacks.holograms")) { con.addPacketListener(new HologramsPacketListener(this, con)); }
-			con.addPacketListener(new PlayerHeadsPacketListener(this, con));
+			if (getConfig().getBoolean("hacks.player-heads-skins")) { con.addPacketListener(new PlayerHeadsPacketListener(this, con)); }
 			if (platform == ServerPlatformIdentifier.SPIGOT) { // Spigot only hacks
 				if (getConfig().getBoolean("hacks.teams")) {
 					con.addPacketListener(new TeamsPacketListener(this, con));

--- a/src/protocolsupportpocketstuff/ProtocolSupportPocketStuff.java
+++ b/src/protocolsupportpocketstuff/ProtocolSupportPocketStuff.java
@@ -18,6 +18,7 @@ import protocolsupportpocketstuff.hacks.bossbars.BossBarPacketListener;
 import protocolsupportpocketstuff.hacks.dimensions.DimensionListener;
 import protocolsupportpocketstuff.hacks.holograms.HologramsPacketListener;
 import protocolsupportpocketstuff.hacks.itemframes.ItemFramesPacketListener;
+import protocolsupportpocketstuff.hacks.playerheads.PlayerHeadsPacketListener;
 import protocolsupportpocketstuff.hacks.teams.TeamsPacketListener;
 import protocolsupportpocketstuff.metadata.MetadataProvider;
 import protocolsupportpocketstuff.packet.handshake.ClientLoginPacket;
@@ -87,6 +88,7 @@ public class ProtocolSupportPocketStuff extends JavaPlugin implements Listener {
 			con.addPacketListener(new ResourcePackListener(this, con));
 			if (getConfig().getBoolean("skins.PEtoPC")) { con.addPacketListener(new SkinPacket().new decodeHandler(this, con)); }
 			if (getConfig().getBoolean("hacks.holograms")) { con.addPacketListener(new HologramsPacketListener(this, con)); }
+			con.addPacketListener(new PlayerHeadsPacketListener(this, con));
 			if (platform == ServerPlatformIdentifier.SPIGOT) { // Spigot only hacks
 				if (getConfig().getBoolean("hacks.teams")) {
 					con.addPacketListener(new TeamsPacketListener(this, con));

--- a/src/protocolsupportpocketstuff/api/util/PocketCon.java
+++ b/src/protocolsupportpocketstuff/api/util/PocketCon.java
@@ -227,6 +227,18 @@ public class PocketCon {
 	}
 
 	/***
+	 * Gets the client unique identifier
+	 * <br/><br/>
+	 * <b>This isn't the server unique identifier for the player</b>, this unique ID is sent by the client during login and
+	 * it is used for skin updates, player list updates and other misc stuff.
+	 * @param player
+	 * @return the client unique identifier
+	 */
+	public static UUID getClientUniqueId(Connection connection) {
+		return (UUID) connection.getMetadata(StuffUtils.CLIENT_UUID_KEY);
+	}
+
+	/***
 	 * Sends a packet to pocket.
 	 * @param connection
 	 * @param packet

--- a/src/protocolsupportpocketstuff/api/util/PocketPlayer.java
+++ b/src/protocolsupportpocketstuff/api/util/PocketPlayer.java
@@ -4,6 +4,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.World.Environment;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
+import protocolsupport.api.Connection;
 import protocolsupport.api.ProtocolSupportAPI;
 import protocolsupport.api.ProtocolType;
 import protocolsupportpocketstuff.api.modals.Modal;
@@ -11,6 +12,7 @@ import protocolsupportpocketstuff.api.modals.callback.ModalCallback;
 import protocolsupportpocketstuff.api.skins.PocketSkinModel;
 import protocolsupportpocketstuff.packet.PEPacket;
 import protocolsupportpocketstuff.storage.Modals;
+import protocolsupportpocketstuff.util.StuffUtils;
 
 import java.util.Collection;
 import java.util.UUID;
@@ -171,6 +173,18 @@ public class PocketPlayer {
 	 */
 	public static String getClientVersion(Player player) {
 		return PocketCon.getClientVersion(ProtocolSupportAPI.getConnection(player));
+	}
+
+	/***
+	 * Gets the client unique identifier
+	 * <br/><br/>
+	 * <b>This isn't the server unique identifier for the player</b>, this unique ID is sent by the client during login and
+	 * it is used for skin updates, player list updates and other misc stuff.
+	 * @param player
+	 * @return the client unique identifier
+	 */
+	public static UUID getClientUniqueId(Player player) {
+		return PocketCon.getClientUniqueId(ProtocolSupportAPI.getConnection(player));
 	}
 
 	/***

--- a/src/protocolsupportpocketstuff/hacks/playerheads/PlayerHeadsPacketListener.java
+++ b/src/protocolsupportpocketstuff/hacks/playerheads/PlayerHeadsPacketListener.java
@@ -1,0 +1,400 @@
+package protocolsupportpocketstuff.hacks.playerheads;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.Validate;
+import org.bukkit.Material;
+import protocolsupport.api.Connection;
+import protocolsupport.api.ProtocolVersion;
+import protocolsupport.libs.com.google.gson.JsonObject;
+import protocolsupport.protocol.serializer.ArraySerializer;
+import protocolsupport.protocol.serializer.ItemStackSerializer;
+import protocolsupport.protocol.serializer.MiscSerializer;
+import protocolsupport.protocol.serializer.PositionSerializer;
+import protocolsupport.protocol.serializer.StringSerializer;
+import protocolsupport.protocol.serializer.VarNumberSerializer;
+import protocolsupport.protocol.typeremapper.pe.PEPacketIDs;
+import protocolsupport.protocol.typeremapper.pe.PESkinModel;
+import protocolsupport.protocol.utils.NBTTagCompoundSerializer;
+import protocolsupport.protocol.utils.datawatcher.DataWatcherObject;
+import protocolsupport.protocol.utils.datawatcher.objects.DataWatcherObjectFloatLe;
+import protocolsupport.protocol.utils.i18n.I18NData;
+import protocolsupport.protocol.utils.types.Position;
+import protocolsupport.utils.CollectionsUtils;
+import protocolsupport.zplatform.itemstack.ItemStackWrapper;
+import protocolsupport.zplatform.itemstack.NBTTagCompoundWrapper;
+import protocolsupport.zplatform.itemstack.NBTTagType;
+import protocolsupportpocketstuff.ProtocolSupportPocketStuff;
+import protocolsupportpocketstuff.api.util.PocketCon;
+import protocolsupportpocketstuff.packet.TileDataUpdatePacket;
+import protocolsupportpocketstuff.packet.play.EntityDestroyPacket;
+import protocolsupportpocketstuff.packet.play.SpawnPlayerPacket;
+import protocolsupportpocketstuff.storage.Skins;
+import protocolsupportpocketstuff.util.StuffUtils;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.SplittableRandom;
+import java.util.UUID;
+
+public class PlayerHeadsPacketListener extends Connection.PacketListener {
+	private ProtocolSupportPocketStuff plugin;
+	private Connection con;
+	private boolean isSpawned = false;
+	private final HashMap<Long, CachedSkullBlock> fakePlayers = new HashMap<Long, CachedSkullBlock>();
+	private static final int PLAYER_SKULL_ID = 144;
+
+	public PlayerHeadsPacketListener(ProtocolSupportPocketStuff plugin, Connection con) {
+		this.plugin = plugin;
+		this.con = con;
+	}
+
+	@Override
+	public void onRawPacketReceiving(RawPacketEvent event) {
+		ByteBuf data = event.getData();
+		int packetId = VarNumberSerializer.readVarInt(data);
+
+		data.readByte();
+		data.readByte();
+
+		if (packetId == PEPacketIDs.PLAYER_MOVE) {
+			if (isSpawned)
+				return;
+
+			isSpawned = true;
+
+			for (CachedSkullBlock cachedSkullBlock : fakePlayers.values()) {
+				cachedSkullBlock.spawn(this);
+			}
+			return;
+		}
+	}
+
+	@Override
+	public void onRawPacketSending(RawPacketEvent event) {
+		ByteBuf data = event.getData();
+		int packetId = VarNumberSerializer.readVarInt(data);
+
+		data.readByte();
+		data.readByte();
+
+		if (packetId == PEPacketIDs.CHANGE_DIMENSION) {
+			System.out.println("CHANGE DIMENSION!!!");
+			for (CachedSkullBlock cachedSkullBlock : fakePlayers.values()) {
+				System.out.println("Killing skull head with ID: " + cachedSkullBlock.getEntityId());
+				PocketCon.sendPocketPacket(con, new EntityDestroyPacket(cachedSkullBlock.getEntityId()));
+			}
+			fakePlayers.clear();
+			return;
+		}
+		if (packetId == PEPacketIDs.MOB_ARMOR_EQUIPMENT) {
+			long entityId = VarNumberSerializer.readVarLong(data);
+
+			ItemStackWrapper itemStack = ItemStackSerializer.readItemStack(data, con.getVersion(), I18NData.DEFAULT_LOCALE, true);
+
+			NBTTagCompoundWrapper tag = itemStack.getTag();
+
+			if (itemStack.isNull() || itemStack.getType() != Material.SKULL_ITEM)
+				return;
+
+			if (tag.getIntNumber("SkullType") != 3) // We only care about player heads
+				return;
+
+			if (!tag.hasKeyOfType("Owner", NBTTagType.COMPOUND))
+				return;
+
+			NBTTagCompoundWrapper owner = tag.getCompound("Owner");
+
+			if (!owner.hasKeyOfType("Properties", NBTTagType.COMPOUND))
+				return;
+
+			String signature = owner.getList("textures").getCompound(0).getString("Signature");
+			String value = owner.getList("textures").getCompound(0).getString("Value");
+
+			String _json = new String(Base64.getDecoder().decode(value));
+
+			JsonObject json = StuffUtils.JSON_PARSER.parse(_json).getAsJsonObject();
+			String skinUrl = json.get("textures").getAsJsonObject().get("SKIN").getAsJsonObject().get("url").getAsString();
+
+			System.out.println("Skin URL: " + skinUrl);
+			return;
+		}
+		if (packetId == PEPacketIDs.TILE_DATA_UPDATE) {
+			Position position = PositionSerializer.readPEPosition(data); // position, we don't care about it, we only care about the position in the compound tag
+			try {
+				NBTTagCompoundWrapper tag = NBTTagCompoundSerializer.readPeTag(data, true);
+				boolean removeTags = parseTag(tag);
+
+				if (removeTags) {
+					tag.remove("Owner");
+					event.setData(new TileDataUpdatePacket(position.getX(), position.getY(), position.getZ(), tag).encode(con));
+				}
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+			return;
+		}
+		if (packetId == PEPacketIDs.UPDATE_BLOCK) {
+			Position position = PositionSerializer.readPEPosition(data);
+			int id = VarNumberSerializer.readVarInt(data);
+
+			System.out.println("Updating block...");
+
+			if (id == PLAYER_SKULL_ID)
+				return;
+
+			System.out.println("It isn't an skull, wow...");
+
+			long asLong = asLong(position.getX(), position.getY(), position.getZ());
+
+			if (!fakePlayers.containsKey(asLong))
+				return;
+
+			System.out.println("And it is cached! Killing it right now :O");
+
+			PocketCon.sendPocketPacket(con, new EntityDestroyPacket(fakePlayers.get(asLong).getEntityId()));
+			fakePlayers.remove(asLong);
+			return;
+		}
+		if (packetId == PEPacketIDs.CHUNK_DATA) {
+			VarNumberSerializer.readSVarInt(data); // chunk X
+			VarNumberSerializer.readSVarInt(data); // chunk Z
+			VarNumberSerializer.readVarInt(data); // length
+			int sectionLength = data.readByte();
+			// System.out.println("Section length: " + sectionLength);
+			// data.skipBytes(10241 * sectionLength);
+			for (int idx = 0; sectionLength > idx; idx++) {
+				data.readByte(); // storage type
+				data.skipBytes(4096 + 2048); // skip data, we don't care about that
+			}
+			data.skipBytes(512); // heights
+			data.skipBytes(256); // biomes
+			data.readByte(); // borders
+			VarNumberSerializer.readSVarInt(data); // extra data
+			while (data.readableBytes() != 0) {
+				// System.out.println("Reading NBT tag...");
+				parseTag(ItemStackSerializer.readTag(data, true, con.getVersion()));
+			}
+		}
+	}
+
+	public static long asLong(int x, int y, int z) {
+		return ((x & 0x3FFFFFFL) << 38) | ((y & 0xFFFL) << 26) | (z & 0x3FFFFFFL);
+	}
+
+	public boolean parseTag(NBTTagCompoundWrapper tag) {
+		// System.out.println("Parsing tag: " + tag);
+		if (!tag.getString("id").equals("Skull"))
+			return false;
+
+		if (!tag.hasKeyOfType("Owner", NBTTagType.COMPOUND))
+			return false;
+
+		NBTTagCompoundWrapper owner = tag.getCompound("Owner");
+
+		if (!owner.hasKeyOfType("Properties", NBTTagType.COMPOUND))
+			return false;
+
+		NBTTagCompoundWrapper properties = owner.getCompound("Properties");
+
+		if (!properties.hasKeyOfType("textures", NBTTagType.LIST))
+			return false;
+
+		String value = properties.getList("textures").getCompound(0).getString("Value");
+
+		String _json = new String(Base64.getDecoder().decode(value));
+
+		JsonObject json = StuffUtils.JSON_PARSER.parse(_json).getAsJsonObject();
+
+		String url = json.get("textures").getAsJsonObject().get("SKIN").getAsJsonObject().get("url").getAsString();
+
+		int x = tag.getIntNumber("x");
+		int y = tag.getIntNumber("y");
+		int z = tag.getIntNumber("z");
+
+		CachedSkullBlock cachedSkullBlock = new CachedSkullBlock(tag, url);
+
+		if (fakePlayers.containsKey(asLong(x, y, z))) {
+			System.out.println("Killing the old fake player...");
+			PocketCon.sendPocketPacket(con, new EntityDestroyPacket(fakePlayers.get(asLong(x, y, z)).getEntityId()));
+		}
+
+		fakePlayers.put(asLong(x, y, z), cachedSkullBlock);
+
+		System.out.println("isSpawned? " + isSpawned);
+
+		if (!isSpawned)
+			return true;
+
+		cachedSkullBlock.spawn(this);
+		return true;
+	}
+
+	protected static void writeSkinData(ProtocolVersion version, ByteBuf serializer, boolean isSkinUpdate, boolean isSlim, byte[] skindata) {
+		PESkinModel model = PESkinModel.getSkinModel(isSlim);
+		if (isSkinUpdate) {
+			StringSerializer.writeString(serializer, version, "6bcfb27d-7e0f-466d-a3d3-3764223e8c3b_Custom");
+		}
+		StringSerializer.writeString(serializer, version, "geometry.Mobs.Skeleton2");
+		if (isSkinUpdate) {
+			//TODO: find out how it is used and if its use matters.
+			StringSerializer.writeString(serializer, version, "Steve");
+		}
+		ArraySerializer.writeByteArray(serializer, version, skindata);
+		ArraySerializer.writeByteArray(serializer, version, new byte[0]); //cape data
+		StringSerializer.writeString(serializer, version, "geometry.Mobs.Skeleton2");
+		try {
+			StringSerializer.writeString(serializer, version, FileUtils.readFileToString(new File("D:\\armor_stand.json")));
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	protected static byte[] toData(BufferedImage skin) {
+		Validate.isTrue(skin.getWidth() == 64, "Must be 64 pixels wide");
+		Validate.isTrue((skin.getHeight() == 64) || (skin.getHeight() == 32), "Must be 64 or 32 pixels high");
+		ByteArrayOutputStream stream = new ByteArrayOutputStream();
+		for (int y = 0; y < skin.getHeight(); y++) {
+			for (int x = 0; x < skin.getWidth(); x++) {
+				Color color = new Color(skin.getRGB(x, y), true);
+				stream.write(color.getRed());
+				stream.write(color.getGreen());
+				stream.write(color.getBlue());
+				stream.write(color.getAlpha());
+			}
+		}
+		return stream.toByteArray();
+	}
+
+	static class CachedSkullBlock {
+		private long entityId = new SplittableRandom().nextLong(Integer.MAX_VALUE, Long.MAX_VALUE);
+		private NBTTagCompoundWrapper tag;
+		private String url;
+		private int dataValue = 1; // TODO
+
+		public CachedSkullBlock(NBTTagCompoundWrapper tag, String url) {
+			this.tag = tag;
+			this.url = url;
+		}
+
+		public long getEntityId() {
+			return entityId;
+		}
+
+		public void spawn(PlayerHeadsPacketListener listener) {
+			System.out.println("Spawning...");
+			if (Skins.INSTANCE.hasPeSkin(url)) {
+				sendFakePlayer(listener, url, Skins.INSTANCE.getPeSkin(url));
+			} else {
+				new Thread() {
+					public void run() {
+						try {
+							BufferedImage image = ImageIO.read(new URL(url));
+							byte[] data = toData(image);
+							sendFakePlayer(listener, url, data);
+							Skins.INSTANCE.cachePeSkin(url, data);
+						} catch (IOException e) {
+							e.printStackTrace();
+						}
+					}
+				}.start();
+			}
+		}
+
+		private void sendFakePlayer(PlayerHeadsPacketListener listener, String url, byte[] data) {
+			int x = tag.getIntNumber("x");
+			int y = tag.getIntNumber("y");
+			int z = tag.getIntNumber("z");
+			int rot = tag.getByteNumber("Rot");
+
+			CollectionsUtils.ArrayMap<DataWatcherObject<?>> metadata = new CollectionsUtils.ArrayMap<>(76);
+
+			metadata.put(39, new DataWatcherObjectFloatLe(1.05f)); // scale
+			metadata.put(54, new DataWatcherObjectFloatLe(0.001f)); // bb width
+			metadata.put(55, new DataWatcherObjectFloatLe(0.001f)); // bb height
+
+			UUID uuid = UUID.randomUUID();
+
+			float yaw = 0;
+			switch (rot) {
+				case 0:
+					yaw = 180F;
+					break;
+				case 1:
+					yaw = 202.5F;
+					break;
+				case 2:
+					yaw = 225F;
+					break;
+				case 3:
+					yaw = 247.5F;
+					break;
+				case 4:
+					yaw = 270F;
+					break;
+				case 5:
+					yaw = 292.5F;
+					break;
+				case 6:
+					yaw = 315F;
+					break;
+				case 7:
+					yaw = 337.5F;
+					break;
+				case 8:
+					yaw = 0F;
+					break;
+				case 9:
+					yaw = 22.5F;
+					break;
+				case 10:
+					yaw = 45F;
+					break;
+				case 11:
+					yaw = 67.5F;
+					break;
+				case 12:
+					yaw = 90F;
+					break;
+				case 13:
+					yaw = 112.5F;
+					break;
+				case 14:
+					yaw = 135F;
+					break;
+				case 15:
+					yaw = 157.5F;
+					break;
+			}
+			SpawnPlayerPacket packet = new SpawnPlayerPacket(
+					uuid,
+					"",
+					entityId,
+					(float) (x + 0.5), y + (float) new SplittableRandom().nextDouble(0, 6), (float) (z + 0.5), // coordinates
+					0, 0, 0, // motion
+					0, 0, yaw, // pitch, head yaw & yaw
+					metadata
+			);
+
+			ByteBuf serializer = Unpooled.buffer();
+			VarNumberSerializer.writeVarInt(serializer, PEPacketIDs.PLAYER_SKIN);
+			serializer.writeByte(0);
+			serializer.writeByte(0);
+			MiscSerializer.writeUUID(serializer, uuid);
+			writeSkinData(listener.con.getVersion(), serializer, true, false, data);
+			PocketCon.sendPocketPacket(listener.con, packet);
+			listener.con.sendRawPacket(MiscSerializer.readAllBytes(serializer));
+
+			TileDataUpdatePacket tileDataUpdatePacket = new TileDataUpdatePacket(x, y, z, tag);
+			PocketCon.sendPocketPacket(listener.con, tileDataUpdatePacket);
+		}
+	}
+}

--- a/src/protocolsupportpocketstuff/hacks/playerheads/PlayerHeadsPacketListener.java
+++ b/src/protocolsupportpocketstuff/hacks/playerheads/PlayerHeadsPacketListener.java
@@ -103,9 +103,7 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 			return;
 		}
 		if (packetId == PEPacketIDs.CHANGE_DIMENSION) {
-			System.out.println("CHANGE DIMENSION!!!");
 			for (CachedSkullBlock cachedSkullBlock : cachedSkullBlocks.values()) {
-				System.out.println("Killing skull head with ID: " + cachedSkullBlock.getEntityId());
 				PocketCon.sendPocketPacket(con, new EntityDestroyPacket(cachedSkullBlock.getEntityId()));
 			}
 			cachedSkullBlocks.clear();
@@ -132,11 +130,7 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 
 			NBTTagCompoundWrapper tag = itemStack.getTag();
 
-			System.out.println(tag);
-
 			String url = getUrlFromSkull(tag, true);
-
-			System.out.println("Equipped Skull URL: " + url);
 
 			selfEquippedCustomSkull = true;
 
@@ -170,12 +164,8 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 		if (packetId == PEPacketIDs.MOB_ARMOR_EQUIPMENT) {
 			long entityId = VarNumberSerializer.readVarLong(data);
 
-			System.out.println("Equip for " + entityId);
-
 			if (!entityIdToUuid.containsKey(entityId))
 				return;
-
-			System.out.println("Contains!");
 
 			ItemStackWrapper itemStack = ItemStackSerializer.readItemStack(data, con.getVersion(), I18NData.DEFAULT_LOCALE, false); // Yes, it is from the client, but we don't want it to remap our stuff
 
@@ -187,15 +177,9 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 				return;
 			}
 
-			System.out.println("And it is really an skull!");
-
 			NBTTagCompoundWrapper tag = itemStack.getTag();
 
-			System.out.println(tag);
-
 			String url = getUrlFromSkull(tag, true);
-
-			System.out.println("Skin URL: " + url);
 
 			hasCustomSkull.add(entityId);
 			new Thread() {
@@ -452,27 +436,6 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 		cachedSkullBlock.spawn(this);
 	}
 
-	/* protected static void writeSkinData2(ProtocolVersion version, ByteBuf serializer, boolean isSkinUpdate, boolean isSlim, byte[] skindata) {
-		PESkinModel model = PESkinModel.getSkinModel(isSlim);
-		if (isSkinUpdate) {
-			StringSerializer.writeString(serializer, version, model.getSkinName());
-		}
-		StringSerializer.writeString(serializer, version, model.getSkinId());
-		if (isSkinUpdate) {
-			//TODO: find out how it is used and if its use matters.
-			StringSerializer.writeString(serializer, version, "Steve");
-		}
-		ArraySerializer.writeByteArray(serializer, version, skindata);
-		ArraySerializer.writeByteArray(serializer, version, new byte[0]); //cape data
-		StringSerializer.writeString(serializer, version, model.getGeometryId());
-		StringSerializer.writeString(serializer, version, model.getGeometryData());
-		try {
-			// StringSerializer.writeString(serializer, version, FileUtils.readFileToString(new File("D:\\custom_models.json")));
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-	} */
-
 	protected static byte[] toData(BufferedImage skin) {
 		Validate.isTrue(skin.getWidth() == 64, "Must be 64 pixels wide");
 		Validate.isTrue((skin.getHeight() == 64) || (skin.getHeight() == 32), "Must be 64 or 32 pixels high");
@@ -511,14 +474,13 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 
 		public void spawn(PlayerHeadsPacketListener listener) {
 			isSpawned = true;
-			System.out.println("Spawning...");
+
 			if (Skins.INSTANCE.hasPeSkin(url)) {
 				sendFakePlayer(listener, url, Skins.INSTANCE.getPeSkin(url));
 			} else {
 				new Thread() {
 					public void run() {
 						try {
-							System.out.println("URL: " + url);
 							BufferedImage image = ImageIO.read(new URL(url));
 							byte[] data = toData(image);
 							sendFakePlayer(listener, url, data);

--- a/src/protocolsupportpocketstuff/hacks/playerheads/PlayerHeadsPacketListener.java
+++ b/src/protocolsupportpocketstuff/hacks/playerheads/PlayerHeadsPacketListener.java
@@ -49,8 +49,8 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 	private ProtocolSupportPocketStuff plugin;
 	private Connection con;
 	private boolean isSpawned = false;
-	private final HashMap<Long, CachedSkullBlock> fakePlayers = new HashMap<Long, CachedSkullBlock>();
-	private static final int PLAYER_SKULL_ID = 144;
+	private final HashMap<Long, CachedSkullBlock> cachedSkullBlocks = new HashMap<Long, CachedSkullBlock>();
+	private static final int SKULL_BLOCK_ID = 144;
 
 	public PlayerHeadsPacketListener(ProtocolSupportPocketStuff plugin, Connection con) {
 		this.plugin = plugin;
@@ -71,7 +71,7 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 
 			isSpawned = true;
 
-			for (CachedSkullBlock cachedSkullBlock : fakePlayers.values()) {
+			for (CachedSkullBlock cachedSkullBlock : cachedSkullBlocks.values()) {
 				cachedSkullBlock.spawn(this);
 			}
 			return;
@@ -88,11 +88,11 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 
 		if (packetId == PEPacketIDs.CHANGE_DIMENSION) {
 			System.out.println("CHANGE DIMENSION!!!");
-			for (CachedSkullBlock cachedSkullBlock : fakePlayers.values()) {
+			for (CachedSkullBlock cachedSkullBlock : cachedSkullBlocks.values()) {
 				System.out.println("Killing skull head with ID: " + cachedSkullBlock.getEntityId());
 				PocketCon.sendPocketPacket(con, new EntityDestroyPacket(cachedSkullBlock.getEntityId()));
 			}
-			fakePlayers.clear();
+			cachedSkullBlocks.clear();
 			return;
 		}
 		if (packetId == PEPacketIDs.MOB_ARMOR_EQUIPMENT) {
@@ -148,20 +148,20 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 
 			System.out.println("Updating block...");
 
-			if (id == PLAYER_SKULL_ID)
+			if (id == SKULL_BLOCK_ID)
 				return;
 
 			System.out.println("It isn't an skull, wow...");
 
 			long asLong = asLong(position.getX(), position.getY(), position.getZ());
 
-			if (!fakePlayers.containsKey(asLong))
+			if (!cachedSkullBlocks.containsKey(asLong))
 				return;
 
 			System.out.println("And it is cached! Killing it right now :O");
 
-			PocketCon.sendPocketPacket(con, new EntityDestroyPacket(fakePlayers.get(asLong).getEntityId()));
-			fakePlayers.remove(asLong);
+			PocketCon.sendPocketPacket(con, new EntityDestroyPacket(cachedSkullBlocks.get(asLong).getEntityId()));
+			cachedSkullBlocks.remove(asLong);
 			return;
 		}
 		if (packetId == PEPacketIDs.CHUNK_DATA) {
@@ -222,12 +222,12 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 
 		CachedSkullBlock cachedSkullBlock = new CachedSkullBlock(tag, url);
 
-		if (fakePlayers.containsKey(asLong(x, y, z))) {
+		if (cachedSkullBlocks.containsKey(asLong(x, y, z))) {
 			System.out.println("Killing the old fake player...");
-			PocketCon.sendPocketPacket(con, new EntityDestroyPacket(fakePlayers.get(asLong(x, y, z)).getEntityId()));
+			PocketCon.sendPocketPacket(con, new EntityDestroyPacket(cachedSkullBlocks.get(asLong(x, y, z)).getEntityId()));
 		}
 
-		fakePlayers.put(asLong(x, y, z), cachedSkullBlock);
+		cachedSkullBlocks.put(asLong(x, y, z), cachedSkullBlock);
 
 		System.out.println("isSpawned? " + isSpawned);
 
@@ -378,7 +378,7 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 					uuid,
 					"",
 					entityId,
-					(float) (x + 0.5), y + (float) new SplittableRandom().nextDouble(0, 6), (float) (z + 0.5), // coordinates
+					(float) (x + 0.5), y, (float) (z + 0.5), // coordinates
 					0, 0, 0, // motion
 					0, 0, yaw, // pitch, head yaw & yaw
 					metadata

--- a/src/protocolsupportpocketstuff/hacks/playerheads/PlayerHeadsPacketListener.java
+++ b/src/protocolsupportpocketstuff/hacks/playerheads/PlayerHeadsPacketListener.java
@@ -303,7 +303,7 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 								skulls.put(position, dataValue);
 							}
 							if (skulls.containsKey(positionAbove)) {
-								skulls.put(position, dataValueAbove);
+								skulls.put(positionAbove, dataValueAbove);
 							}
 						}
 					}
@@ -318,7 +318,7 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 				NBTTagCompoundWrapper tag = ItemStackSerializer.readTag(data, true, con.getVersion());
 
 				if (!isSkull(tag))
-					return;
+					continue;
 
 				int x = tag.getIntNumber("x");
 				int y = tag.getIntNumber("y");

--- a/src/protocolsupportpocketstuff/hacks/playerheads/PlayerHeadsPacketListener.java
+++ b/src/protocolsupportpocketstuff/hacks/playerheads/PlayerHeadsPacketListener.java
@@ -28,6 +28,7 @@ import protocolsupportpocketstuff.ProtocolSupportPocketStuff;
 import protocolsupportpocketstuff.api.util.PocketCon;
 import protocolsupportpocketstuff.packet.TileDataUpdatePacket;
 import protocolsupportpocketstuff.packet.play.EntityDestroyPacket;
+import protocolsupportpocketstuff.packet.play.SkinPacket;
 import protocolsupportpocketstuff.packet.play.SpawnPlayerPacket;
 import protocolsupportpocketstuff.storage.Skins;
 import protocolsupportpocketstuff.util.StuffUtils;
@@ -52,7 +53,7 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 	private final HashMap<Long, CachedSkullBlock> cachedSkullBlocks = new HashMap<>();
 	private final HashMap<Long, UUID> entityIdToUuid = new HashMap<>();
 	private final HashSet<Long> hasCustomSkull = new HashSet<>();
-
+	private static final String SKULL_MODEL = StuffUtils.getResourceAsString("models/fake_skull_block.json");
 	private static final int SKULL_BLOCK_ID = 144;
 
 	public PlayerHeadsPacketListener(ProtocolSupportPocketStuff plugin, Connection con) {
@@ -398,26 +399,6 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 		cachedSkullBlock.spawn(this);
 	}
 
-	protected static void writeSkinData(ProtocolVersion version, ByteBuf serializer, boolean isSkinUpdate, boolean isSlim, byte[] skindata) {
-		PESkinModel model = PESkinModel.getSkinModel(isSlim);
-		if (isSkinUpdate) {
-			StringSerializer.writeString(serializer, version, "6bcfb27d-7e0f-466d-a3d3-3764223e8c3b_Custom");
-		}
-		StringSerializer.writeString(serializer, version, "geometry.Mobs.Skeleton2");
-		if (isSkinUpdate) {
-			//TODO: find out how it is used and if its use matters.
-			StringSerializer.writeString(serializer, version, "Steve");
-		}
-		ArraySerializer.writeByteArray(serializer, version, skindata);
-		ArraySerializer.writeByteArray(serializer, version, new byte[0]); //cape data
-		StringSerializer.writeString(serializer, version, "geometry.Mobs.Skeleton2");
-		try {
-			StringSerializer.writeString(serializer, version, FileUtils.readFileToString(new File("D:\\armor_stand.json")));
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-	}
-
 	protected static void writeSkinData2(ProtocolVersion version, ByteBuf serializer, boolean isSkinUpdate, boolean isSlim, byte[] skindata) {
 		PESkinModel model = PESkinModel.getSkinModel(isSlim);
 		if (isSkinUpdate) {
@@ -603,6 +584,16 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 			MiscSerializer.writeUUID(serializer, listener.con.getVersion(), uuid);
 			writeSkinData(listener.con.getVersion(), serializer, true, false, data);
 			PocketCon.sendPocketPacket(listener.con, packet);
+			PocketCon.sendPocketPacket(listener.con, new SkinPacket(
+					uuid,
+					"d5c91b67-3d30-4aee-b99f-859542f02ea9_Skull",
+					"geometry.Tiles.PSPEFakeSkull",
+					"Steve",
+					data,
+					new byte[0],
+					"geometry.Tiles.PSPEFakeSkull",
+					SKULL_MODEL
+			));
 			listener.con.sendRawPacket(MiscSerializer.readAllBytes(serializer));
 
 			TileDataUpdatePacket tileDataUpdatePacket = new TileDataUpdatePacket(x, y, z, tag);

--- a/src/protocolsupportpocketstuff/hacks/playerheads/PlayerHeadsPacketListener.java
+++ b/src/protocolsupportpocketstuff/hacks/playerheads/PlayerHeadsPacketListener.java
@@ -11,6 +11,7 @@ import protocolsupport.protocol.serializer.MiscSerializer;
 import protocolsupport.protocol.serializer.PositionSerializer;
 import protocolsupport.protocol.serializer.StringSerializer;
 import protocolsupport.protocol.serializer.VarNumberSerializer;
+import protocolsupport.protocol.typeremapper.pe.PEInventory;
 import protocolsupport.protocol.typeremapper.pe.PEPacketIDs;
 import protocolsupport.protocol.typeremapper.pe.PESkinModel;
 import protocolsupport.protocol.utils.NBTTagCompoundSerializer;
@@ -57,7 +58,7 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 	// Constants
 	private static final int SKULL_BLOCK_ID = 144;
 	private static final int SKULL_ITEM_ID = 397;
-	private static final int ARMOR_WINDOW_ID = 120;
+	private static final int ARMOR_WINDOW_ID = PEInventory.PESource.POCKET_ARMOR_EQUIPMENT;
 
 	public PlayerHeadsPacketListener(ProtocolSupportPocketStuff plugin, Connection con) {
 		this.plugin = plugin;
@@ -103,9 +104,6 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 			return;
 		}
 		if (packetId == PEPacketIDs.CHANGE_DIMENSION) {
-			for (CachedSkullBlock cachedSkullBlock : cachedSkullBlocks.values()) {
-				PocketCon.sendPocketPacket(con, new EntityDestroyPacket(cachedSkullBlock.getEntityId()));
-			}
 			cachedSkullBlocks.clear();
 			return;
 		}
@@ -284,7 +282,7 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 							int id = data.readUnsignedByte();
 
 							if (id == SKULL_BLOCK_ID) {
-								skulls.put(StuffUtils.toLong(chunkXStart + x, (idx * 16) + y, chunkZStart + z), -1);
+								skulls.put(StuffUtils.convertCoordinatesToLong(chunkXStart + x, (idx * 16) + y, chunkZStart + z), -1);
 							}
 						}
 					}
@@ -292,8 +290,8 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 				for (int x = 0; x < 16; x++) {
 					for (int z = 0; z < 16; z++) {
 						for (int y = 0; y < 16; y += 2) {
-							long position = StuffUtils.toLong(chunkXStart + x, (idx * 16) + y, chunkZStart + z);
-							long positionAbove = StuffUtils.toLong(chunkXStart + x, (idx * 16) + y + 1, chunkZStart + z);
+							long position = StuffUtils.convertCoordinatesToLong(chunkXStart + x, (idx * 16) + y, chunkZStart + z);
+							long positionAbove = StuffUtils.convertCoordinatesToLong(chunkXStart + x, (idx * 16) + y + 1, chunkZStart + z);
 							int state = data.readUnsignedByte();
 
 							int dataValueAbove = state >> 4;

--- a/src/protocolsupportpocketstuff/hacks/playerheads/PlayerHeadsPacketListener.java
+++ b/src/protocolsupportpocketstuff/hacks/playerheads/PlayerHeadsPacketListener.java
@@ -312,7 +312,7 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 		VarNumberSerializer.writeVarInt(serializer, PEPacketIDs.PLAYER_SKIN);
 		serializer.writeByte(0);
 		serializer.writeByte(0);
-		MiscSerializer.writeUUID(serializer, uuid);
+		MiscSerializer.writeUUID(serializer, con.getVersion(), uuid);
 		writeSkinData2(con.getVersion(), serializer, true, false, originalSkin);
 		con.sendRawPacket(MiscSerializer.readAllBytes(serializer));
 	}
@@ -326,7 +326,7 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 		VarNumberSerializer.writeVarInt(serializer, PEPacketIDs.PLAYER_SKIN);
 		serializer.writeByte(0);
 		serializer.writeByte(0);
-		MiscSerializer.writeUUID(serializer, uuid);
+		MiscSerializer.writeUUID(serializer, con.getVersion(), uuid);
 		writeSkinData2(con.getVersion(), serializer, true, false, originalSkin);
 		con.sendRawPacket(MiscSerializer.readAllBytes(serializer));
 	}
@@ -600,7 +600,7 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 			VarNumberSerializer.writeVarInt(serializer, PEPacketIDs.PLAYER_SKIN);
 			serializer.writeByte(0);
 			serializer.writeByte(0);
-			MiscSerializer.writeUUID(serializer, uuid);
+			MiscSerializer.writeUUID(serializer, listener.con.getVersion(), uuid);
 			writeSkinData(listener.con.getVersion(), serializer, true, false, data);
 			PocketCon.sendPocketPacket(listener.con, packet);
 			listener.con.sendRawPacket(MiscSerializer.readAllBytes(serializer));

--- a/src/protocolsupportpocketstuff/hacks/playerheads/PlayerHeadsPacketListener.java
+++ b/src/protocolsupportpocketstuff/hacks/playerheads/PlayerHeadsPacketListener.java
@@ -129,7 +129,6 @@ public class PlayerHeadsPacketListener extends Connection.PacketListener {
 				return;
 			}
 
-			System.out.println("And it is really an skull!");
 
 			NBTTagCompoundWrapper tag = itemStack.getTag();
 

--- a/src/protocolsupportpocketstuff/metadata/MetadataProvider.java
+++ b/src/protocolsupportpocketstuff/metadata/MetadataProvider.java
@@ -12,6 +12,6 @@ public class MetadataProvider extends PEMetaProvider {
 
 	@Override
 	public String getInteractText(NetworkEntity networkEntity) {
-		return null;
+		return "Interact";
 	}
 }

--- a/src/protocolsupportpocketstuff/metadata/MetadataProvider.java
+++ b/src/protocolsupportpocketstuff/metadata/MetadataProvider.java
@@ -9,4 +9,9 @@ public class MetadataProvider extends PEMetaProvider {
 	public float getEntitySize(NetworkEntity networkEntity) {
 		return PocketUtils.hasCustomScale(networkEntity.getId()) ? PocketUtils.getCustomScale(networkEntity.getId()) : 1;
 	}
+
+	@Override
+	public String getInteractText(NetworkEntity networkEntity) {
+		return null;
+	}
 }

--- a/src/protocolsupportpocketstuff/packet/play/SkinPacket.java
+++ b/src/protocolsupportpocketstuff/packet/play/SkinPacket.java
@@ -47,7 +47,7 @@ public class SkinPacket extends PEPacket {
 	@Override
 	public void toData(Connection connection, ByteBuf serializer) {
 		ProtocolVersion version = connection.getVersion();
-		MiscSerializer.writeUUID(serializer, uuid);
+		MiscSerializer.writeUUID(serializer, connection.getVersion(), uuid);
 		StringSerializer.writeString(serializer, version, skinId);
 		StringSerializer.writeString(serializer, version, skinName);
 		StringSerializer.writeString(serializer, version, previousName);

--- a/src/protocolsupportpocketstuff/packet/play/SpawnPlayerPacket.java
+++ b/src/protocolsupportpocketstuff/packet/play/SpawnPlayerPacket.java
@@ -52,7 +52,7 @@ public class SpawnPlayerPacket extends PEPacket {
 
 	@Override
 	public void toData(Connection connection, ByteBuf serializer) {
-		MiscSerializer.writeUUID(serializer, uuid);
+		MiscSerializer.writeUUID(serializer, connection.getVersion(), uuid);
 		StringSerializer.writeString(serializer, connection.getVersion(), name);
 		VarNumberSerializer.writeSVarLong(serializer, entityId); // entity ID
 		VarNumberSerializer.writeVarLong(serializer, entityId); // runtime ID

--- a/src/protocolsupportpocketstuff/skin/SkinListener.java
+++ b/src/protocolsupportpocketstuff/skin/SkinListener.java
@@ -20,8 +20,6 @@ import protocolsupportpocketstuff.api.util.SkinUtils;
 import protocolsupportpocketstuff.util.MineskinThread;
 import protocolsupportpocketstuff.util.StuffUtils;
 
-import java.util.Map;
-
 public class SkinListener implements Listener {
 	
 	private ProtocolSupportPocketStuff plugin;
@@ -32,7 +30,6 @@ public class SkinListener implements Listener {
 
 	@EventHandler
 	public void onPlayerPropertiesResolve(PlayerPropertiesResolveEvent e) {
-		System.out.println("INSTANCE: " + e.getConnection().getPlayer() + " ~ " + e.getName());
 		Connection con = e.getConnection();
 		if (PocketCon.isPocketConnection(con)) {
 			if (con.hasMetadata(StuffUtils.APPLY_SKIN_ON_JOIN_KEY)) {
@@ -41,10 +38,6 @@ public class SkinListener implements Listener {
 				e.addProperty(new PlayerPropertiesResolveEvent.ProfileProperty(StuffUtils.SKIN_PROPERTY_NAME, skinDataWrapper.getValue(), skinDataWrapper.getSignature()));
 				con.removeMetadata(StuffUtils.APPLY_SKIN_ON_JOIN_KEY);
 			}
-		}
-		System.out.println("props");
-		for (Map.Entry<String, PlayerPropertiesResolveEvent.ProfileProperty> prop : e.getProperties().entrySet()) {
-			System.out.println(prop.getKey() + " ~ " + prop.getValue());
 		}
 	}
 

--- a/src/protocolsupportpocketstuff/skin/SkinListener.java
+++ b/src/protocolsupportpocketstuff/skin/SkinListener.java
@@ -20,6 +20,8 @@ import protocolsupportpocketstuff.api.util.SkinUtils;
 import protocolsupportpocketstuff.util.MineskinThread;
 import protocolsupportpocketstuff.util.StuffUtils;
 
+import java.util.Map;
+
 public class SkinListener implements Listener {
 	
 	private ProtocolSupportPocketStuff plugin;
@@ -30,6 +32,7 @@ public class SkinListener implements Listener {
 
 	@EventHandler
 	public void onPlayerPropertiesResolve(PlayerPropertiesResolveEvent e) {
+		System.out.println("INSTANCE: " + e.getConnection().getPlayer() + " ~ " + e.getName());
 		Connection con = e.getConnection();
 		if (PocketCon.isPocketConnection(con)) {
 			if (con.hasMetadata(StuffUtils.APPLY_SKIN_ON_JOIN_KEY)) {
@@ -38,6 +41,10 @@ public class SkinListener implements Listener {
 				e.addProperty(new PlayerPropertiesResolveEvent.ProfileProperty(StuffUtils.SKIN_PROPERTY_NAME, skinDataWrapper.getValue(), skinDataWrapper.getSignature()));
 				con.removeMetadata(StuffUtils.APPLY_SKIN_ON_JOIN_KEY);
 			}
+		}
+		System.out.println("props");
+		for (Map.Entry<String, PlayerPropertiesResolveEvent.ProfileProperty> prop : e.getProperties().entrySet()) {
+			System.out.println(prop.getKey() + " ~ " + prop.getValue());
 		}
 	}
 

--- a/src/protocolsupportpocketstuff/skin/SkinListener.java
+++ b/src/protocolsupportpocketstuff/skin/SkinListener.java
@@ -1,6 +1,7 @@
 package protocolsupportpocketstuff.skin;
 
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import protocolsupport.api.Connection;
@@ -28,13 +29,14 @@ public class SkinListener implements Listener {
 		this.plugin = plugin;
 	}
 
-	@EventHandler
+	@EventHandler(priority = EventPriority.HIGHEST)
 	public void onPlayerPropertiesResolve(PlayerPropertiesResolveEvent e) {
 		Connection con = e.getConnection();
 		if (PocketCon.isPocketConnection(con)) {
 			if (con.hasMetadata(StuffUtils.APPLY_SKIN_ON_JOIN_KEY)) {
 				plugin.debug("Applying cached skin for " + e.getConnection() + "...");
 				SkinUtils.SkinDataWrapper skinDataWrapper = (SkinUtils.SkinDataWrapper) con.getMetadata(StuffUtils.APPLY_SKIN_ON_JOIN_KEY);
+				e.removeProperty("textures"); // Remove old texture property, if it had one
 				e.addProperty(new PlayerPropertiesResolveEvent.ProfileProperty(StuffUtils.SKIN_PROPERTY_NAME, skinDataWrapper.getValue(), skinDataWrapper.getSignature()));
 				con.removeMetadata(StuffUtils.APPLY_SKIN_ON_JOIN_KEY);
 			}

--- a/src/protocolsupportpocketstuff/util/StuffUtils.java
+++ b/src/protocolsupportpocketstuff/util/StuffUtils.java
@@ -18,6 +18,10 @@ public class StuffUtils {
 	public static final String APPLY_SKIN_ON_JOIN_KEY = "applySkinOnJoin";
 	public static final String CLIENT_INFO_KEY = "clientInformationMap";
 
+	public static long toLong(int x, int y, int z) { // From ProtocolSupport's "Position" class, used here so we don't need to initialize an Position object every time
+		return ((x & 0x3FFFFFFL) << 38) | ((y & 0xFFFL) << 26) | ((z & 0x3FFFFFFL));
+	}
+
 	public static String toLegacy(IChatBaseComponent s) {
 		StringBuilder builder = new StringBuilder();
 		legacy(builder, s);

--- a/src/protocolsupportpocketstuff/util/StuffUtils.java
+++ b/src/protocolsupportpocketstuff/util/StuffUtils.java
@@ -24,6 +24,7 @@ public class StuffUtils {
 	public static final String SKIN_PROPERTY_NAME = "textures";
 	public static final String APPLY_SKIN_ON_JOIN_KEY = "applySkinOnJoin";
 	public static final String CLIENT_INFO_KEY = "clientInformationMap";
+	public static final String CLIENT_UUID_KEY = "clientUniqueId";
 	private static final String RESOURCES_DIRECTORY = "resources";
 
 	public static BufferedReader getResource(String name) {

--- a/src/protocolsupportpocketstuff/util/StuffUtils.java
+++ b/src/protocolsupportpocketstuff/util/StuffUtils.java
@@ -44,7 +44,7 @@ public class StuffUtils {
 		return ProtocolSupportPocketStuff.class.getClassLoader().getResourceAsStream(RESOURCES_DIRECTORY + "/" + name);
 	}
 
-	public static long toLong(int x, int y, int z) { // From ProtocolSupport's "Position" class, used here so we don't need to initialize an Position object every time
+	public static long convertCoordinatesToLong(int x, int y, int z) { // From ProtocolSupport's "Position" class, used here so we don't need to initialize an Position object every time
 		return ((x & 0x3FFFFFFL) << 38) | ((y & 0xFFFL) << 26) | ((z & 0x3FFFFFFL));
 	}
 

--- a/src/protocolsupportpocketstuff/util/StuffUtils.java
+++ b/src/protocolsupportpocketstuff/util/StuffUtils.java
@@ -4,10 +4,17 @@ import net.minecraft.server.v1_12_R1.ChatComponentText;
 import net.minecraft.server.v1_12_R1.ChatModifier;
 import net.minecraft.server.v1_12_R1.EnumChatFormat;
 import net.minecraft.server.v1_12_R1.IChatBaseComponent;
+import org.apache.commons.io.IOUtils;
 import org.bukkit.ChatColor;
 import protocolsupport.libs.com.google.gson.Gson;
 import protocolsupport.libs.com.google.gson.JsonParser;
+import protocolsupportpocketstuff.ProtocolSupportPocketStuff;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 public class StuffUtils {
@@ -17,6 +24,24 @@ public class StuffUtils {
 	public static final String SKIN_PROPERTY_NAME = "textures";
 	public static final String APPLY_SKIN_ON_JOIN_KEY = "applySkinOnJoin";
 	public static final String CLIENT_INFO_KEY = "clientInformationMap";
+	private static final String RESOURCES_DIRECTORY = "resources";
+
+	public static BufferedReader getResource(String name) {
+		return new BufferedReader(new InputStreamReader(getResourceAsStream(name), StandardCharsets.UTF_8));
+	}
+
+	public static String getResourceAsString(String name) {
+		try {
+			return IOUtils.toString(getResource(name));
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	public static InputStream getResourceAsStream(String name) {
+		return ProtocolSupportPocketStuff.class.getClassLoader().getResourceAsStream(RESOURCES_DIRECTORY + "/" + name);
+	}
 
 	public static long toLong(int x, int y, int z) { // From ProtocolSupport's "Position" class, used here so we don't need to initialize an Position object every time
 		return ((x & 0x3FFFFFFL) << 38) | ((y & 0xFFFL) << 26) | ((z & 0x3FFFFFFL));


### PR DESCRIPTION
![https://cdn.discordapp.com/attachments/268353819409252352/381397983033294848/Screenshot_20171118-085713.png](https://cdn.discordapp.com/attachments/268353819409252352/381397983033294848/Screenshot_20171118-085713.png)

![https://cdn.discordapp.com/attachments/268353819409252352/381397983033294849/Screenshot_20171118-085732.png](https://cdn.discordapp.com/attachments/268353819409252352/381397983033294849/Screenshot_20171118-085732.png)

(The skull is swapped to a nametag when the player equips the skull because, if we kept the skull item in the player's head, the changed skin would be replaced by the skull)

It still has some issues with skulls (when you change worlds the entities aren't removed because the change dimension packet is never sent (ProtocolSupport bug); when you join the server while equipping an skull the skin won't be applied; new players won't see your fancy skin; unequipping the skull makes your skin have the "Steve" model even if your model is an "Alex" model) but nothing "omg the server is super broken!", so...

![http://i0.kym-cdn.com/photos/images/newsfeed/001/300/459/03f.gif](http://i0.kym-cdn.com/photos/images/newsfeed/001/300/459/03f.gif)